### PR TITLE
Purely use `rustdoc_json::Builder`

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -2,12 +2,13 @@ use std::{fs::read_to_string, io::Write};
 
 use goldenfile::Mint;
 use public_api::PublicApi;
-use rustdoc_json::BuildOptions;
 
 #[test]
 fn api() {
-    let json_path =
-        rustdoc_json::Builder::build(BuildOptions::default().all_features(true)).unwrap();
+    let json_path = rustdoc_json::Builder::default()
+        .all_features(true)
+        .build()
+        .unwrap();
 
     let mut mint = Mint::new(".");
     let mut goldenfile = mint.new_goldenfile("api.golden").unwrap();


### PR DESCRIPTION
Looks like `rustdoc_json` hasn't sufficiently marked it's deprecated API as deprecated, because your code is more complicated than it needs to be :)

(I'll try to improve on deprecation warnings in an upcoming `rustdoc_json` release)