### PR TITLE
Update README.md - make it easy to spot root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ cargo +nightly install ftzz
 Generate a reproducibly random tree in the current directory with *approximately* 1 million files:
 
 ```console
-$ ftzz g simple -n 1M
+$ ftzz g ./simple -n 1M
 About 1,000,000 files will be generated in approximately 1,000 directories distributed across a tree of maximum depth 5 where each directory contains approximately 4 other directories.
 Created 1,002,953 files across 1,193 directories.
 
@@ -31,7 +31,7 @@ Created 1,002,953 files across 1,193 directories.
 Generate *exactly* 1 million files:
 
 ```console
-$ ftzz g exact -en 1M
+$ ftzz g ./exact -en 1M
 Exactly 1,000,000 files will be generated in approximately 1,000 directories distributed across a tree of maximum depth 5 where each directory contains approximately 4 other directories.
 Created 1,000,000 files across 1,193 directories.
 
@@ -40,7 +40,7 @@ Created 1,000,000 files across 1,193 directories.
 Generate ~10_000 files with ~1 MB of random data spread across them:
 
 ```console
-$ ftzz g with_data -n 10K -b 1M
+$ ftzz g ./with_data -n 10K -b 1M
 About 10,000 files will be generated in approximately 1,000 directories distributed across a tree of maximum depth 5 where each directory contains approximately 4 other directories. Each file will contain approximately 100 bytes of random data.
 Created 9,419 files (929.4 KB) across 1,138 directories.
 
@@ -51,11 +51,11 @@ structure given the same inputs. To generate variations on a structure with the 
 change the starting seed:
 
 ```console
-$ ftzz g unseeded -n 100
+$ ftzz g ./unseeded -n 100
 About 100 files will be generated in approximately 100 directories distributed across a tree of maximum depth 5 where each directory contains approximately 3 other directories.
 Created 32 files across 214 directories.
 
-$ ftzz g seeded -n 100 --seed 42 # Or $RANDOM
+$ ftzz g ./seeded -n 100 --seed 42 # Or $RANDOM
 About 100 files will be generated in approximately 100 directories distributed across a tree of maximum depth 5 where each directory contains approximately 3 other directories.
 Created 78 files across 59 directories.
 


### PR DESCRIPTION
I've mistaken root folders to subcommands, this make it clear. I thought to also put the folders after the options, as it is in the `--help`, but it breaks this example:
```sh
ftzz g ./seeded -n 100 --seed 42
```

If you'd like I can mention `$RANDOM` somewhere else. Though it's probably worth mention why would one prefer it to unseeded then and I have no idea :)